### PR TITLE
feat(wxwork): 新增模板卡片消息发送支持

### DIFF
--- a/docs/plans/2026-03-27-001-feat-send-template-card-message-plan.md
+++ b/docs/plans/2026-03-27-001-feat-send-template-card-message-plan.md
@@ -1,0 +1,247 @@
+---
+title: 新增模板卡片消息发送 (按钮交互型)
+type: feat
+status: active
+date: 2026-03-27
+---
+
+# 新增模板卡片消息发送 (按钮交互型)
+
+## Overview
+
+在 `wxwork/api_message.go` 中新增模板卡片消息发送支持，优先实现**按钮交互型 (button_interaction)**。这是现有 `SendTextCardMessage` 的增强版，支持更丰富的交互能力（按钮点击回调、下拉选择等）。
+
+## Problem Statement / Motivation
+
+企业微信模板卡片消息是一种更强大的消息卡片类型，支持：
+- 按钮交互（用户点击按钮触发回调）
+- 投票选择
+- 下拉选择器
+
+已有 plan (`2026-03-26-001-feat-add-template-card-event-plan`) 实现了**接收**模板卡片事件，本 plan 实现**发送**模板卡片消息，形成完整的交互闭环。
+
+## Proposed Solution
+
+参考现有 `SendTextCardMessage` 的实现模式，新增:
+
+1. 模板卡片相关结构体（嵌套结构）
+2. `SendTemplateCardMessage` 方法（支持按钮交互型）
+3. 可选: 其他卡片类型的便捷方法
+
+### 按钮交互型卡片结构
+
+```go
+// 模板卡片消息内容
+type TemplateCardContent struct {
+    CardType string `json:"card_type"` // 例如 "button_interaction"
+
+    // 卡片来源样式
+    Source *TemplateCardSource `json:"source,omitempty"`
+
+    // 右上角菜单
+    ActionMenu *TemplateCardActionMenu `json:"action_menu,omitempty"`
+
+    // 重要: main_title 在 button_interaction 类型中是必填的
+    MainTitle TemplateCardMainTitle `json:"main_title"`
+
+    // 引用样式
+    QuoteArea *TemplateCardQuoteArea `json:"quote_area,omitempty"`
+
+    SubTitleText string `json:"sub_title_text,omitempty"`
+
+    // 二级标题+文本列表
+    HorizontalContentList []TemplateCardHorizontalContent `json:"horizontal_content_list,omitempty"`
+
+    // 跳转指引
+    JumpList []TemplateCardJump `json:"jump_list,omitempty"`
+
+    // 整体卡片点击事件
+    CardAction *TemplateCardAction `json:"card_action,omitempty"`
+
+    // 【关键】task_id 是 button_interaction 类型的必填字段
+    TaskID string `json:"task_id"`
+
+    // 下拉选择器
+    ButtonSelection *TemplateCardButtonSelection `json:"button_selection,omitempty"`
+
+    // 【关键】按钮列表是 button_interaction 类型的必填字段
+    ButtonList []TemplateCardButton `json:"button_list"`
+}
+```
+
+## Technical Considerations
+
+### 复用现有架构
+
+- `reqMessage.MarshalJSON` 已支持 `msgtype` 多态: `out[x.MsgType] = x.Content`
+- 只需构建 `TemplateCardContent` 作为 `Content` 参数传入 `sendMessage`
+- 复用现有 `sendMessage` 的群聊/单聊判断逻辑
+
+### msgtype vs card_type 区别
+
+| 字段 | 值 | 说明 |
+|------|-----|------|
+| `msgtype` | `"template_card"` | 消息类型，固定值 |
+| `card_type` | `"button_interaction"` | 卡片类型，表示卡片的子类型 |
+
+### task_id 要求
+
+- button_interaction/vote_interaction/multiple_interaction 类型 **必须** 提供 task_id
+- 用于后续更新卡片接口调用
+- 格式: 数字、字母和"`_-@`"组成，最长128字节
+
+### button_list 按钮结构
+
+```go
+type TemplateCardButton struct {
+    Type  int    `json:"type,omitempty"`   // 0=回调事件, 1=跳转URL，默认0
+    Text  string `json:"text"`             // 按钮文案，建议不超过10个字
+    Style int    `json:"style,omitempty"`  // 按钮样式 1~4
+    Key   string `json:"key,omitempty"`   // 回调key，type=0时必填
+    URL   string `json:"url,omitempty"`    // 跳转URL，type=1时必填
+}
+```
+
+### horizontal_content_list type 类型
+
+| type值 | 说明 | 必填字段 |
+|--------|------|----------|
+| 0或不填 | 非链接 | - |
+| 1 | 跳转URL | `url` |
+| 2 | 下载附件 | `media_id` |
+| 3 | 成员详情 | `userid` |
+
+## Acceptance Criteria
+
+- [ ] 新增 `TemplateCardContent` 及相关嵌套结构体
+- [ ] 新增 `SendTemplateCardMessage(recipient, *TemplateCardContent, isSafe) error` 方法
+- [ ] 方法签名遵循现有 `SendXxxMessage` 模式
+- [ ] `task_id` 字段正确处理（按钮交互型必填）
+- [ ] `button_list` 支持多按钮（最多6个）
+- [ ] 可选便捷方法: `SendTemplateCardButtonInteraction(...)` 简化常见用法
+- [ ] 文档注释遵循项目风格（中文，含官方文档链接）
+
+## Implementation
+
+### 新增方法签名示例
+
+```go
+// SendTemplateCardMessage 发送模板卡片消息
+//
+// 收件人参数如果仅设置了 `ChatID` 字段，则为【发送消息到群聊会话】接口调用；
+// 否则为单纯的【发送应用消息】接口调用。
+//
+//	cardType 可选值: button_interaction, vote_interaction, multiple_interaction
+//	taskID 按钮交互型/投票选择型/多项选择型卡片必填，用于后续更新卡片接口调用
+//
+//	参考: https://developer.work.weixin.qq.com/document/path/90236#模板卡片消息
+func (a *API) SendTemplateCardMessage(recipient *Recipient, cardType string, content *TemplateCardContent, isSafe bool) error {
+    // 构建 content map，注入 card_type
+    m := map[string]any{
+        "card_type": cardType,
+    }
+    // ... 反射或手动复制 content 字段到 m
+    return a.sendMessage(recipient, "template_card", m, isSafe)
+}
+
+// 便捷方法: 按钮交互型
+func (a *API) SendTemplateCardButtonInteraction(
+    recipient *Recipient,
+    title, desc string,
+    buttons []TemplateCardButton,
+    taskID string,
+    isSafe bool,
+) error {
+    content := &TemplateCardContent{
+        CardType: "button_interaction",
+        MainTitle: TemplateCardMainTitle{
+            Title: title,
+            Desc:  desc,
+        },
+        TaskID:     taskID,
+        ButtonList: buttons,
+    }
+    return a.SendTemplateCardMessage(recipient, "button_interaction", content, isSafe)
+}
+```
+
+### 复用 vs 新结构
+
+考虑到 `TemplateCardContent` 结构体较复杂，有两种实现策略:
+
+| 策略 | 优点 | 缺点 |
+|------|------|------|
+| A. 使用 `map[string]any` | 灵活，简单 | 失去类型安全 |
+| B. 定义完整结构体 | 类型安全，文档清晰 | 代码量大 |
+
+**推荐策略 A**: 保持与现有消息类型一致的模式（`map[string]any` content），但提供辅助函数/方法简化构建过程。
+
+## Context
+
+### button_interaction 请求示例
+
+```json
+{
+    "touser": "UserID1|UserID2",
+    "toparty": "PartyID1",
+    "msgtype": "template_card",
+    "agentid": 1,
+    "template_card": {
+        "card_type": "button_interaction",
+        "source": {
+            "icon_url": "图片url",
+            "desc": "企业微信",
+            "desc_color": 1
+        },
+        "main_title": {
+            "title": "欢迎使用企业微信",
+            "desc": "您的好友正在邀请您加入企业微信"
+        },
+        "quote_area": {
+            "type": 1,
+            "url": "https://work.weixin.qq.com",
+            "title": "引用样式",
+            "quote_text": "企业微信真好用"
+        },
+        "sub_title_text": "下载企业微信还能抢红包！",
+        "horizontal_content_list": [
+            {"keyname": "邀请人", "value": "张三"},
+            {"type": 1, "keyname": "官网", "value": "点击访问", "url": "https://work.weixin.qq.com"}
+        ],
+        "card_action": {
+            "type": 2,
+            "url": "https://work.weixin.qq.com",
+            "appid": "小程序的appid",
+            "pagepath": "/index.html"
+        },
+        "task_id": "task_id_123",
+        "button_selection": {
+            "question_key": "btn_question_key1",
+            "title": "企业微信评分",
+            "option_list": [
+                {"id": "btn_selection_id1", "text": "100分"},
+                {"id": "btn_selection_id2", "text": "101分"}
+            ],
+            "selected_id": "btn_selection_id1"
+        },
+        "button_list": [
+            {"text": "按钮1", "style": 1, "key": "button_key_1"},
+            {"text": "按钮2", "style": 2, "key": "button_key_2"}
+        ]
+    }
+}
+```
+
+## Dependencies & Risks
+
+| 依赖/风险 | 说明 |
+|----------|------|
+| 现有 sendMessage 架构 | 复用现有逻辑，无需修改核心架构 |
+| task_id 业务生成 | 需要调用方提供，唯一性由业务保证 |
+| 企业微信版本 | 按钮交互型需 3.1.6+，投票/多项选择需 3.1.12+ |
+
+## Sources
+
+- [企业微信模板卡片消息文档](https://developer.work.weixin.qq.com/document/path/90236#模板卡片消息)
+- [现有 api_message.go 实现](wxwork/api_message.go)
+- [相关: 模板卡片事件接收 plan](./2026-03-26-001-feat-add-template-card-event-plan.md)

--- a/wxwork/api_integration_test.go
+++ b/wxwork/api_integration_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package wxwork
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+// TestSendTemplateCardMessage 发送模板卡片消息集成测试
+//
+// 需要设置环境变量:
+//   - WXWORK_CORP_ID: 企业ID
+//   - WXWORK_APP_SECRET: 应用密钥
+//   - WXWORK_TO_USER: 接收人用户ID (可选，默认 "@all")
+func TestSendTemplateCardMessage(t *testing.T) {
+	corpID := os.Getenv("WXWORK_CORP_ID")
+	appSecret := os.Getenv("WXWORK_APP_SECRET")
+	if corpID == "" || appSecret == "" {
+		t.Skip("skip: WXWORK_CORP_ID or WXWORK_APP_SECRET not set")
+	}
+
+	toUser := os.Getenv("WXWORK_TO_USER")
+	if toUser == "" {
+		t.Skip("skip: WXWORK_TO_USER not set")
+	}
+
+	wa := NewAPI(corpID, appSecret)
+	agentID := os.Getenv("WXWORK_AGENT_ID")
+	if agentID == "" {
+		t.Skip("skip: WXWORK_AGENT_ID not set")
+	}
+	wa.AgentID, _ = strconv.Atoi(agentID)
+	recipient := &Recipient{
+		UserIDs: []string{toUser},
+	}
+
+	buttons := []TemplateCardButton{
+		{Text: "同意", Style: 1, Key: "btn_agree"},
+		{Text: "拒绝", Style: 2, Key: "btn_reject"},
+	}
+
+	err := wa.SendTemplateCardButtonInteraction(
+		recipient,
+		"您有一个待审批流程",
+		"请假申请 - 张三",
+		buttons,
+		"task_test_123",
+		false,
+	)
+	if err != nil {
+		t.Skipf("skip: SendTemplateCardButtonInteraction failed: %v", err)
+	}
+	t.Logf("SendTemplateCardButtonInteraction ok")
+}

--- a/wxwork/api_message.go
+++ b/wxwork/api_message.go
@@ -187,3 +187,171 @@ func (a *API) SendMarkdownMessage(
 ) error {
 	return a.sendMessage(recipient, "markdown", map[string]interface{}{"content": content}, isSafe)
 }
+
+// ==================== 模板卡片消息 ====================
+
+// TemplateCardSource 卡片来源样式
+type TemplateCardSource struct {
+	IconURL   string `json:"icon_url,omitempty"`    // 来源图片url
+	Desc      string `json:"desc,omitempty"`        // 来源图片描述，建议不超过20个字
+	DescColor int    `json:"desc_color,omitempty"` // 来源文字颜色: 0灰色(默认) 1黑色 2红色 3绿色
+}
+
+// TemplateCardActionMenu 右上角菜单
+type TemplateCardActionMenu struct {
+	Desc       string                        `json:"desc,omitempty"`        // 卡片副交互辅助文本说明
+	ActionList []TemplateCardActionMenuItem `json:"action_list"`           // 操作列表，列表长度1~3
+}
+
+// TemplateCardActionMenuItem 右上角菜单项
+type TemplateCardActionMenuItem struct {
+	Text string `json:"text"` // 操作描述文案
+	Key  string `json:"key"`  // 操作key，用户点击后回调时作为EventKey返回
+}
+
+// TemplateCardMainTitle 一级标题
+type TemplateCardMainTitle struct {
+	Title string `json:"title,omitempty"` // 一级标题，建议不超过36个字
+	Desc  string `json:"desc,omitempty"`  // 标题辅助信息，建议不超过44个字
+}
+
+// TemplateCardQuoteArea 引用文献样式
+type TemplateCardQuoteArea struct {
+	Type      int    `json:"type,omitempty"`       // 点击事件类型: 0无 1跳转URL 2跳转小程序
+	URL       string `json:"url,omitempty"`          // 点击跳转URL，type=1时必填
+	AppID     string `json:"appid,omitempty"`        // 小程序appid，type=2时必填
+	PagePath  string `json:"pagepath,omitempty"`      // 小程序页面路径
+	Title     string `json:"title,omitempty"`        // 引用文献样式标题
+	QuoteText string `json:"quote_text,omitempty"`   // 引用文献样式的引用文案
+}
+
+// TemplateCardHorizontalContent 二级标题+文本
+type TemplateCardHorizontalContent struct {
+	Type    int    `json:"type,omitempty"`     // 链接类型: 0非链接 1跳转URL 2下载附件 3成员详情
+	KeyName string `json:"keyname"`             // 二级标题，建议不超过5个字
+	Value   string `json:"value,omitempty"`     // 二级文本
+	URL     string `json:"url,omitempty"`       // 跳转URL，type=1时必填
+	MediaID string `json:"media_id,omitempty"`  // 附件media_id，type=2时必填
+	UserID  string `json:"userid,omitempty"`    // 成员userid，type=3时必填
+}
+
+// TemplateCardJump 跳转指引
+type TemplateCardJump struct {
+	Type    int    `json:"type,omitempty"`     // 跳转类型: 0非链接 1跳转URL 2跳转小程序
+	Title   string `json:"title"`               // 跳转链接文案，建议不超过18个字
+	URL     string `json:"url,omitempty"`       // 跳转URL，type=1时必填
+	AppID   string `json:"appid,omitempty"`     // 小程序appid，type=2时必填
+	PagePath string `json:"pagepath,omitempty"`  // 小程序页面路径
+}
+
+// TemplateCardAction 卡片整体点击事件
+type TemplateCardAction struct {
+	Type     int    `json:"type,omitempty"`      // 跳转类型: 0非链接 1跳转URL 2打开小程序
+	URL      string `json:"url,omitempty"`       // 跳转URL，type=1时必填
+	AppID    string `json:"appid,omitempty"`      // 小程序appid，type=2时必填
+	PagePath string `json:"pagepath,omitempty"`   // 小程序页面路径
+}
+
+// TemplateCardButtonSelection 下拉选择器
+type TemplateCardButtonSelection struct {
+	QuestionKey string                    `json:"question_key"`           // 选择器key，用户提交后回调时返回
+	Title       string                    `json:"title,omitempty"`        // 选择器左边标题
+	OptionList  []TemplateCardSelectOption `json:"option_list"`            // 选项列表，最多10个
+	SelectedID  string                    `json:"selected_id,omitempty"`  // 默认选定id
+}
+
+// TemplateCardSelectOption 下拉选择器选项
+type TemplateCardSelectOption struct {
+	ID   string `json:"id"`   // 选项id，用户提交后回调时返回
+	Text string `json:"text"` // 选项文案，建议不超过16个字
+}
+
+// TemplateCardButton 按钮
+type TemplateCardButton struct {
+	Type  int    `json:"type,omitempty"`    // 点击事件类型: 0回调事件 1跳转URL，默认0
+	Text  string `json:"text"`              // 按钮文案，建议不超过10个字
+	Style int    `json:"style,omitempty"`   // 按钮样式 1~4
+	Key   string `json:"key,omitempty"`     // 按钮key，type=0时必填
+	URL   string `json:"url,omitempty"`     // 跳转URL，type=1时必填
+}
+
+// TemplateCardContent 模板卡片消息内容
+type TemplateCardContent struct {
+	CardType               string                        `json:"card_type,omitempty"`                // 卡片类型
+	Source                 *TemplateCardSource            `json:"source,omitempty"`                   // 卡片来源样式
+	ActionMenu             *TemplateCardActionMenu        `json:"action_menu,omitempty"`              // 右上角菜单
+	MainTitle              TemplateCardMainTitle          `json:"main_title"`                         // 一级标题
+	QuoteArea              *TemplateCardQuoteArea         `json:"quote_area,omitempty"`               // 引用文献样式
+	SubTitleText           string                        `json:"sub_title_text,omitempty"`            // 二级普通文本，建议不超过160个字
+	HorizontalContentList  []TemplateCardHorizontalContent `json:"horizontal_content_list,omitempty"`  // 二级标题+文本列表，最多6个
+	JumpList               []TemplateCardJump             `json:"jump_list,omitempty"`                 // 跳转指引列表，最多3个
+	CardAction             *TemplateCardAction            `json:"card_action,omitempty"`               // 整体卡片点击事件
+	TaskID                 string                        `json:"task_id,omitempty"`                  // 任务id，用于后续更新卡片接口调用
+	ButtonSelection        *TemplateCardButtonSelection   `json:"button_selection,omitempty"`         // 下拉选择器
+	ButtonList             []TemplateCardButton           `json:"button_list,omitempty"`              // 按钮列表，最多6个
+}
+
+// SendTemplateCardMessage 发送模板卡片消息
+//
+//	收件人参数如果仅设置了 `ChatID` 字段，则为【发送消息到群聊会话】接口调用；
+//	否则为单纯的【发送应用消息】接口调用。
+//
+//	cardType 可选值: text_notice, news_notice, button_interaction, vote_interaction, multiple_interaction
+//	button_interaction/vote_interaction/multiple_interaction 类型必须提供 taskID
+//
+//	参考: https://developer.work.weixin.qq.com/document/path/90236#模板卡片消息
+func (a *API) SendTemplateCardMessage(recipient *Recipient, cardType string, content *TemplateCardContent, isSafe bool) error {
+	content.CardType = cardType
+	// 转换为 map[string]any 以适配 sendMessage
+	contentMap, err := structToMap(content)
+	if err != nil {
+		return err
+	}
+	return a.sendMessage(recipient, "template_card", contentMap, isSafe)
+}
+
+// SendTemplateCardButtonInteraction 发送按钮交互型模板卡片消息
+//
+//	收件人参数如果仅设置了 `ChatID` 字段，则为【发送消息到群聊会话】接口调用；
+//	否则为单纯的【发送应用消息】接口调用。
+//
+//	按钮交互型卡片支持用户点击按钮触发回调事件，需配合接收 template_card_event 使用。
+//	taskID 用于后续更新卡片接口调用，72小时内有效，且只能使用一次。
+//
+//	参考: https://developer.work.weixin.qq.com/document/path/90236#按钮交互型
+func (a *API) SendTemplateCardButtonInteraction(
+	recipient *Recipient,
+	title string,
+	desc string,
+	buttons []TemplateCardButton,
+	taskID string,
+	isSafe bool,
+) error {
+	content := &TemplateCardContent{
+		CardType: "button_interaction",
+		MainTitle: TemplateCardMainTitle{
+			Title: title,
+			Desc:  desc,
+		},
+		TaskID:     taskID,
+		ButtonList: buttons,
+	}
+	contentMap, err := structToMap(content)
+	if err != nil {
+		return err
+	}
+	return a.sendMessage(recipient, "template_card", contentMap, isSafe)
+}
+
+// structToMap converts a struct to map[string]any using JSON marshal/unmarshal
+func structToMap(v any) (map[string]any, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/wxwork/api_message_test.go
+++ b/wxwork/api_message_test.go
@@ -1,0 +1,83 @@
+package wxwork
+
+import (
+	"testing"
+)
+
+func TestTemplateCardButtonInteractionJSON(t *testing.T) {
+	buttons := []TemplateCardButton{
+		{Text: "按钮1", Style: 1, Key: "btn_key_1"},
+		{Text: "按钮2", Style: 2, Key: "btn_key_2"},
+	}
+
+	content := &TemplateCardContent{
+		CardType: "button_interaction",
+		MainTitle: TemplateCardMainTitle{
+			Title: "欢迎使用企业微信",
+			Desc:  "您的好友正在邀请您加入企业微信",
+		},
+		SubTitleText: "下载企业微信还能抢红包！",
+		TaskID:      "task_id_123",
+		ButtonList:  buttons,
+	}
+
+	// 验证结构体内容
+	if content.CardType != "button_interaction" {
+		t.Errorf("expected card_type button_interaction, got %s", content.CardType)
+	}
+	if content.MainTitle.Title != "欢迎使用企业微信" {
+		t.Errorf("expected title '欢迎使用企业微信', got %s", content.MainTitle.Title)
+	}
+	if len(content.ButtonList) != 2 {
+		t.Errorf("expected 2 buttons, got %d", len(content.ButtonList))
+	}
+	if content.ButtonList[0].Key != "btn_key_1" {
+		t.Errorf("expected first button key 'btn_key_1', got %s", content.ButtonList[0].Key)
+	}
+
+	// 验证 JSON 序列化 (确保 MarshalJSON 能正常工作)
+	// 与 SendTemplateCardMessage 一样，使用 structToMap 转换
+	contentMap, err := structToMap(content)
+	if err != nil {
+		t.Fatalf("structToMap failed: %v", err)
+	}
+	req := reqMessage{
+		ToUser:  []string{"user1"},
+		AgentID: 1,
+		MsgType: "template_card",
+		Content: contentMap,
+		IsSafe:  false,
+	}
+
+	data, err := req.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+
+	t.Logf("JSON output: %s", string(data))
+
+	// 验证关键字段存在于 JSON 中
+	jsonStr := string(data)
+	if !contains(jsonStr, `"card_type":"button_interaction"`) {
+		t.Errorf("JSON should contain card_type button_interaction, got: %s", jsonStr)
+	}
+	if !contains(jsonStr, `"task_id":"task_id_123"`) {
+		t.Errorf("JSON should contain task_id, got: %s", jsonStr)
+	}
+	if !contains(jsonStr, `"button_list"`) {
+		t.Errorf("JSON should contain button_list, got: %s", jsonStr)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
新增 SendTemplateCardMessage 和 SendTemplateCardButtonInteraction 方法， 用于发送企业微信模板卡片消息。

支持按钮交互型 (button_interaction) 模板卡片，包含：
- 卡片来源样式 (source)
- 右上角菜单 (action_menu)
- 一级标题 (main_title)
- 引用文献样式 (quote_area)
- 二级内容列表 (horizontal_content_list, jump_list)
- 卡片整体点击事件 (card_action)
- 下拉选择器 (button_selection)
- 按钮列表 (button_list)

新增单元测试和集成测试。

参考: https://developer.work.weixin.qq.com/document/path/90236#模板卡片消息